### PR TITLE
Added support for Route Record Indicator packets.

### DIFF
--- a/xbee/base.py
+++ b/xbee/base.py
@@ -265,9 +265,9 @@ class XBeeBase(threading.Thread):
                 # Store the number of bytes specified
 
                 # Are we trying to read beyond the last data element?
-                if index + field['len'] > len(data):
-                    raise ValueError(
-                        "Response packet was shorter than expected")
+                expected_len = index + field['len']
+                if expected_len > len(data):
+                    raise ValueError("Response packet was shorter than expected; expected: %d, got: %d bytes" % (expected_len, len(data)))
 
                 field_data = data[index:index + field['len']]
                 info[field['name']] = field_data
@@ -287,9 +287,7 @@ class XBeeBase(threading.Thread):
 
         # If there are more bytes than expected, raise an exception
         if index < len(data):
-            raise ValueError(
-                "Response packet was longer than expected; expected: %d, got: %d bytes" % (index,
-                                                                                           len(data)))
+            raise ValueError("Response packet was longer than expected; expected: %d, got: %d bytes" % (index, len(data)))
 
         # Apply parsing rules if any exist
         if 'parsing' in packet:
@@ -299,7 +297,6 @@ class XBeeBase(threading.Thread):
                     # Apply the parse function to the indicated field and
                     # replace the raw data with the result
                     info[parse_rule[0]] = parse_rule[1](self, info)
-
         return info
 
     def _parse_samples_header(self, io_bytes):

--- a/xbee/zigbee.py
+++ b/xbee/zigbee.py
@@ -99,8 +99,8 @@ class ZigBee(XBeeBase):
                          'structure':
                             [{'name':'source_addr_long','len':8},
                              {'name':'source_addr',     'len':2},
-                             {'name':'options',         'len':1},
-                             {'name':'number_addresses','len':1},
+                             {'name':'receive_options', 'len':1},
+                             {'name':'hop_count',       'len':1},
                              {'name':'addresses',       'len':None}]},
                      b"\x91":
                         {'name':'rx_explicit',

--- a/xbee/zigbee.py
+++ b/xbee/zigbee.py
@@ -94,14 +94,6 @@ class ZigBee(XBeeBase):
                              {'name':'source_addr',     'len':2},
                              {'name':'options',         'len':1},
                              {'name':'rf_data',         'len':None}]},
-                     b"\xa1": # See http://ftp1.digi.com/support/documentation/90002002.pdf
-                        {'name':'route_record_indicator',
-                         'structure':
-                            [{'name':'source_addr_long','len':8},
-                             {'name':'source_addr',     'len':2},
-                             {'name':'receive_options', 'len':1},
-                             {'name':'hop_count',       'len':1},
-                             {'name':'addresses',       'len':None}]},
                      b"\x91":
                         {'name':'rx_explicit',
                          'structure':
@@ -159,6 +151,14 @@ class ZigBee(XBeeBase):
                           'parsing': [('parameter',
                                        lambda self, original: self._parse_IS_at_response(original))]
                              },
+                     b"\xa1": # See http://ftp1.digi.com/support/documentation/90002002.pdf
+                        {'name':'route_record_indicator',
+                         'structure':
+                            [{'name':'source_addr_long','len':8},
+                             {'name':'source_addr',     'len':2},
+                             {'name':'receive_options', 'len':1},
+                             {'name':'hop_count',       'len':1},
+                             {'name':'addresses',       'len':None}]},
                      b"\x95":
                         {'name':'node_id_indicator',
                          'structure':

--- a/xbee/zigbee.py
+++ b/xbee/zigbee.py
@@ -94,7 +94,7 @@ class ZigBee(XBeeBase):
                              {'name':'source_addr',     'len':2},
                              {'name':'options',         'len':1},
                              {'name':'rf_data',         'len':None}]},
-                     b"\xa1":
+                     b"\xa1": # See http://ftp1.digi.com/support/documentation/90002002.pdf
                         {'name':'route_record_indicator',
                          'structure':
                             [{'name':'source_addr_long','len':8},
@@ -147,7 +147,7 @@ class ZigBee(XBeeBase):
                                      ('parameter',
                                        lambda self, original: self._parse_ND_at_response(original))]
                              },
-                     b"\x97": #Checked GDR (not sure about parameter, could be 4 bytes)
+                     b"\x97": # Checked GDR (not sure about parameter, could be 4 bytes)
                         {'name':'remote_at_response',
                          'structure':
                             [{'name':'frame_id',        'len':1},

--- a/xbee/zigbee.py
+++ b/xbee/zigbee.py
@@ -94,6 +94,14 @@ class ZigBee(XBeeBase):
                              {'name':'source_addr',     'len':2},
                              {'name':'options',         'len':1},
                              {'name':'rf_data',         'len':None}]},
+                     b"\xa1":
+                        {'name':'route_record_indicator',
+                         'structure':
+                            [{'name':'source_addr_long','len':8},
+                             {'name':'source_addr',     'len':2},
+                             {'name':'options',         'len':1},
+                             {'name':'number_addresses','len':1},
+                             {'name':'addresses',       'len':None}]},
                      b"\x91":
                         {'name':'rx_explicit',
                          'structure':
@@ -166,7 +174,7 @@ class ZigBee(XBeeBase):
                              {'name':'digi_profile_id', 'len':2},
                              {'name':'manufacturer_id', 'len':2}]}
                      }
-    
+
     def _parse_IS_at_response(self, packet_info):
         """
         If the given packet is a successful remote AT response for an IS


### PR DESCRIPTION
Adds support for API Route Record Indicator packets (Type a1). Solves issue #14.
Currently if a Route Record Indicator packet is received by an XBee then the Python XBee library would crash with error: 
   "Unrecognized response packet with id byte \xa1"

Adding packet type to dictionary.