### PR TITLE
Break on Error fix, Zigbee Test fix, Comments fix.

### DIFF
--- a/xbee/base.py
+++ b/xbee/base.py
@@ -1,5 +1,5 @@
 """
-xbee.py
+base.py
 
 By Paul Malmsten, 2010
 Inspired by code written by Amit Synderman and Marco Sangalli

--- a/xbee/base.py
+++ b/xbee/base.py
@@ -107,7 +107,9 @@ class XBeeBase(threading.Thread):
                 # Unexpected thread quit.
                 if self._error_callback:
                     self._error_callback(e)
-                break
+                # Do not break on error as this is not thread safe
+                # See: http://axotron.se/blog/problems-with-python-xbee-2-2-3-package/
+                # break
 
     def _wait_for_frame(self):
         """

--- a/xbee/tests/test_base.py
+++ b/xbee/tests/test_base.py
@@ -1,6 +1,6 @@
 #! /usr/bin/python
 """
-test_xbee.py
+test_base.py
 
 By Paul Malmsten, 2010
 pmalmsten@gmail.com

--- a/xbee/tests/test_zigbee.py
+++ b/xbee/tests/test_zigbee.py
@@ -243,6 +243,6 @@ class TestParseZigBeeIOData(unittest.TestCase):
         channel to 10 bits of precision.
         """ 
         data = b'\x01\x00\x00\x80\x0D\x18'
-        expected_results = [{'adc-7':0xD18}]
+        expected_results = [{'adc-7':280}]
         results = self.zigbee._parse_samples(data)
         self.assertEqual(results, expected_results)

--- a/xbee/zigbee.py
+++ b/xbee/zigbee.py
@@ -150,7 +150,7 @@ class ZigBee(XBeeBase):
                           'parsing': [('parameter',
                                        lambda self, original: self._parse_IS_at_response(original))]
                              },
-                     b"\xa1": # See http://ftp1.digi.com/support/documentation/90002002.pdf
+                     b"\xa1": # See http://www.digi.com/resources/documentation/digidocs/pdfs/90002002.pdf
                         {'name':'route_record_indicator',
                          'structure':
                             [{'name':'source_addr_long','len':8},


### PR DESCRIPTION
This PR has been raised to fix a few little niggles:

1. Do not break on error.
Commented out the 'break' statement in base.py on _error_callback. I have done this as it is not thread safe and meant that threads would hang (break) and the main code is not aware, this in turn appears like the thread has hung (but no error messages are presented to the user).
Further information on this issue can be seen here: http://axotron.se/blog/problems-with-python-xbee-2-2-3-package/ 

2. Correcting header comment filenames.
There are a couple of headers with the wrong filename.
Correcting base.py and test_base.py.

3. Fixing broken test_zigbee test.
Fixing test_parse_dio_adc_supply_voltage_not_clamped test which is complaining that adc-7 does not equal 280.

4. Correcting XBee/XBee-PRO S2C ZigBee document link
Fixing broken link to XBee documentation in relation to the recently added Route Record Indicator packets PR16.
Was: http://ftp1.digi.com/support/documentation/90002002.pdf
Now: http://www.digi.com/resources/documentation/digidocs/pdfs/90002002.pdf