### PR TITLE
Revert "Break on Error fix, Zigbee Test fix, Comments fix."

### DIFF
--- a/xbee/base.py
+++ b/xbee/base.py
@@ -1,5 +1,5 @@
 """
-base.py
+xbee.py
 
 By Paul Malmsten, 2010
 Inspired by code written by Amit Synderman and Marco Sangalli
@@ -107,9 +107,7 @@ class XBeeBase(threading.Thread):
                 # Unexpected thread quit.
                 if self._error_callback:
                     self._error_callback(e)
-                # Do not break on error as this is not thread safe
-                # See: http://axotron.se/blog/problems-with-python-xbee-2-2-3-package/
-                # break
+                break
 
     def _wait_for_frame(self):
         """

--- a/xbee/tests/test_base.py
+++ b/xbee/tests/test_base.py
@@ -1,6 +1,6 @@
 #! /usr/bin/python
 """
-test_base.py
+test_xbee.py
 
 By Paul Malmsten, 2010
 pmalmsten@gmail.com

--- a/xbee/tests/test_zigbee.py
+++ b/xbee/tests/test_zigbee.py
@@ -243,6 +243,6 @@ class TestParseZigBeeIOData(unittest.TestCase):
         channel to 10 bits of precision.
         """ 
         data = b'\x01\x00\x00\x80\x0D\x18'
-        expected_results = [{'adc-7':280}]
+        expected_results = [{'adc-7':0xD18}]
         results = self.zigbee._parse_samples(data)
         self.assertEqual(results, expected_results)

--- a/xbee/zigbee.py
+++ b/xbee/zigbee.py
@@ -150,7 +150,7 @@ class ZigBee(XBeeBase):
                           'parsing': [('parameter',
                                        lambda self, original: self._parse_IS_at_response(original))]
                              },
-                     b"\xa1": # See http://www.digi.com/resources/documentation/digidocs/pdfs/90002002.pdf
+                     b"\xa1": # See http://ftp1.digi.com/support/documentation/90002002.pdf
                         {'name':'route_record_indicator',
                          'structure':
                             [{'name':'source_addr_long','len':8},


### PR DESCRIPTION
Reverts nioinnovation/python-xbee#18

Unit test broke after merge. Reverting.

`test_parse_dio_adc_supply_voltage_not_clamped`