### PR TITLE
Correct base filename & documentation link comments

### DIFF
--- a/xbee/base.py
+++ b/xbee/base.py
@@ -1,5 +1,5 @@
 """
-xbee.py
+base.py
 
 By Paul Malmsten, 2010
 Inspired by code written by Amit Synderman and Marco Sangalli

--- a/xbee/tests/test_base.py
+++ b/xbee/tests/test_base.py
@@ -1,6 +1,6 @@
 #! /usr/bin/python
 """
-test_xbee.py
+test_base.py
 
 By Paul Malmsten, 2010
 pmalmsten@gmail.com

--- a/xbee/zigbee.py
+++ b/xbee/zigbee.py
@@ -150,7 +150,7 @@ class ZigBee(XBeeBase):
                           'parsing': [('parameter',
                                        lambda self, original: self._parse_IS_at_response(original))]
                              },
-                     b"\xa1": # See http://ftp1.digi.com/support/documentation/90002002.pdf
+                     b"\xa1": # See http://www.digi.com/resources/documentation/digidocs/pdfs/90002002.pdf
                         {'name':'route_record_indicator',
                          'structure':
                             [{'name':'source_addr_long','len':8},


### PR DESCRIPTION
Following the reversion of PR18 which contained a handful of different fixes I have now broken it down into in smaller individual PR's to allow each fix to be discussed and committed individually.

This PR is a the simple fix up of a few comments (so should not affect any functionality). Correcting a couple of header comment filenames and updating a broken URL to Digi documentation.