### PR TITLE
Add requirement file with pyserial dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+pyserial


### PR DESCRIPTION
Adding requirements.txt with pyserial dependency. This stops Travis CI complaining with:
```
$ pip --version
pip 6.0.7 from /home/travis/virtualenv/python2.7.9/lib/python2.7/site-packages (python 2.7)
Could not locate requirements.txt. Override the install: key in your .travis.yml to install dependencies.
```

With the requirements.txt file in place Travis CI is happier:
```
0.45s$ pip install -r requirements.txt
Collecting pyserial (from -r requirements.txt (line 1))
  Downloading pyserial-3.1.1-py2.py3-none-any.whl (200kB)
    100% |################################| 200kB 2.5MB/s 
Installing collected packages: pyserial
Successfully installed pyserial-3.1.1
```