### PR TITLE
Added optional timeout to wait_read_frame function.

### DIFF
--- a/xbee/base.py
+++ b/xbee/base.py
@@ -109,7 +109,7 @@ class XBeeBase(threading.Thread):
                     self._error_callback(e)
                 break
 
-    def _wait_for_frame(self):
+    def _wait_for_frame(self, timeout = 0):
         """
         _wait_for_frame: None -> binary data
 
@@ -123,7 +123,15 @@ class XBeeBase(threading.Thread):
         """
         frame = APIFrame(escaped=self._escaped)
 
+        # Note the function call start time
+        start_time = time.time()
+
         while True:
+                # Return if the timeout has expired. Safe here because
+                # received frame assembly has not started.
+                if timeout and (time.time() - start_time > timeout):
+                    return None
+
                 if self._callback and not self._thread_continue:
                     raise ThreadQuitException
 
@@ -396,7 +404,7 @@ class XBeeBase(threading.Thread):
         self._write(self._build_command(cmd, **kwargs))
 
 
-    def wait_read_frame(self):
+    def wait_read_frame(self, timeout = 0):
         """
         wait_read_frame: None -> frame info dictionary
 
@@ -406,8 +414,12 @@ class XBeeBase(threading.Thread):
         and returns the resulting dictionary
         """
 
-        frame = self._wait_for_frame()
-        return self._split_response(frame.data)
+        frame = self._wait_for_frame(timeout)
+        # Only try to split the response if there actually is one.
+        if frame:
+            return self._split_response(frame.data)
+        else:
+            return None
 
     def __getattr__(self, name):
         """


### PR DESCRIPTION
This function is dangerous because in the absence of an active XBee network (e.g. while debugging code) it is literally a black hole; Once the interpreter goes in, it will never come out. Adding a timeout here simplifies testing. It also makes it safer to call the function in an externally-managed thread.