### PR TITLE
Do not break on error as this is not thread safe

### DIFF
--- a/xbee/base.py
+++ b/xbee/base.py
@@ -107,7 +107,9 @@ class XBeeBase(threading.Thread):
                 # Unexpected thread quit.
                 if self._error_callback:
                     self._error_callback(e)
-                break
+                # Do not break on error as this is not thread safe
+                # See: http://axotron.se/blog/problems-with-python-xbee-2-2-3-package/
+                # break
 
     def _wait_for_frame(self):
         """

--- a/xbee/base.py
+++ b/xbee/base.py
@@ -107,9 +107,7 @@ class XBeeBase(threading.Thread):
                 # Unexpected thread quit.
                 if self._error_callback:
                     self._error_callback(e)
-                # Do not break on error as this is not thread safe
-                # See: http://axotron.se/blog/problems-with-python-xbee-2-2-3-package/
-                # break
+
 
     def _wait_for_frame(self):
         """


### PR DESCRIPTION
Following the reversion of PR18 which contained a handful of different fixes I have now broken it down into in smaller individual PR's to allow each fix to be discussed and committed individually.

This PR has been raised to trigger discussion as to a more appropriate action and (for now) simply comments out the 'break' statement in base.py on _error_callback. I have done this as it is not thread safe and meant that threads would hang (break) and the main code is not aware, this in turn appears like the thread has hung (but no error messages are presented to the user).

It may be that there is a more appropriate solution? I am happy to alter/add to this PR further if people feel necessary.

Further information on this issue can be seen here: http://axotron.se/blog/problems-with-python-xbee-2-2-3-package/