### PR TITLE
Improved Fake Serial device used by unit tests

### DIFF
--- a/xbee/tests/Fake.py
+++ b/xbee/tests/Fake.py
@@ -27,7 +27,7 @@ class Serial(object):
         self.stopbits = stopbits
         self.xonxoff  = xonxoff
         self.rtscts   = rtscts
-        self._isOpen  = True        
+        self._is_open = True        
         
         self._data_written = ""
         self._read_data    = ""
@@ -94,7 +94,7 @@ class Serial(object):
             'stopbits' : self.stopbits, 
             'xonxoff'  : self.xonxoff, 
             'rtscts'   : self.rtscts 
-        };
+        }
         return settings
 
     def set_read_data( self, data ):
@@ -120,7 +120,7 @@ class Serial(object):
         Returns a string representation of the serial class.
         """
         return  "Serial<id=0xa81c10, open=%s>( port='%s', baudrate=%d," \
-               % ( str(self.is_open), self.port, self.baudrate ) \
+               % ( str(self._is_open), self.port, self.baudrate ) \
                + " bytesize=%d, parity='%s', stopbits=%d, xonxoff=%d, rtscts=%d)"\
                % ( self.bytesize, self.parity, self.stopbits, self.xonxoff,
                    self.rtscts )

--- a/xbee/tests/test_fake.py
+++ b/xbee/tests/test_fake.py
@@ -8,22 +8,23 @@ pmalmsten@gmail.com
 Tests fake device objects for proper functionality.
 """
 import unittest
-from xbee.tests.Fake import FakeReadDevice
+from xbee.tests.Fake import Serial
 
-class TestFakeReadDevice(unittest.TestCase):
+class TestFakeSerialRead(unittest.TestCase):
     """
-    FakeReadDevice class should work as intended to emluate a serial 
-    port
+    Fake Serial class should work as intended to emluate reading from a serial port.
     """
+
     def setUp(self):
         """
-        Create a fake read device for each test
+        Create a fake read device for each test.
         """
-        self.device = FakeReadDevice("test")
-    
+        self.device = Serial()
+        self.device.set_read_data("test")
+
     def test_read_single_byte(self):
         """
-        reading one byte at a time should work as expected
+        Reading one byte at a time should work as expected.
         """
         self.assertEqual(self.device.read(), 't')
         self.assertEqual(self.device.read(), 'e')
@@ -32,13 +33,14 @@ class TestFakeReadDevice(unittest.TestCase):
         
     def test_read_multiple_bytes(self):
         """
-        reading multiple bytes at a time should work as expected
+        Reading multiple bytes at a time should work as expected.
         """
         self.assertEqual(self.device.read(3), 'tes')
         self.assertEqual(self.device.read(), 't')
         
-    def test_read_too_many(self):
+    def test_write(self):
         """
-        attempting to read too many bytes should raise an exception
+        Test serial write function.
         """
-        self.assertRaises(ValueError, self.device.read, 5)
+        self.device.write("Hello World")
+        self.assertEqual(self.device.get_data_written(), "Hello World")

--- a/xbee/tests/test_ieee.py
+++ b/xbee/tests/test_ieee.py
@@ -507,7 +507,7 @@ class TestSendShorthand(unittest.TestCase):
         calling send should write a full API frame containing the
         API AT command packet to the serial device.
         """
-       
+
         # Send an AT command
         self.xbee.at(frame_id=stringToBytes('A'), command=stringToBytes('MY'), parameter=b'\x00\x00')
         
@@ -619,7 +619,7 @@ class TestReadFromDevice(unittest.TestCase):
         # ADC0 value of 255
         sample = b'\x00\xAA\x00\xFF'
         data = header + sample
-       
+
         device = Serial()
         device.set_read_data(APIFrame(data = b'\x97D\x00\x13\xa2\x00@oG\xe4v\x1aIS\x00' + data).output())
         
@@ -689,7 +689,7 @@ class TestReadFromDevice(unittest.TestCase):
                 super(BadReadDevice, self).__init__()
                 self.set_read_data(data)
             
-            def in_waiting(self):
+            def inWaiting(self):
                 return 1
                 
             def read(self, length=1):

--- a/xbee/tests/test_ieee.py
+++ b/xbee/tests/test_ieee.py
@@ -8,7 +8,7 @@ pmalmsten@gmail.com
 Tests the XBee (IEEE 802.15.4) implementation class for XBee API compliance
 """
 import unittest, sys, traceback
-from xbee.tests.Fake import FakeDevice, FakeReadDevice
+from xbee.tests.Fake import Serial
 from xbee.ieee import XBee
 from xbee.frame import APIFrame
 from xbee.python2to3 import byteToInt, intToByte, stringToBytes
@@ -443,7 +443,7 @@ class TestWriteToDevice(unittest.TestCase):
         API AT command packet to the serial device.
         """
         
-        serial_port = FakeDevice()
+        serial_port = Serial()
         xbee = XBee(serial_port)
         
         # Send an AT command
@@ -451,7 +451,8 @@ class TestWriteToDevice(unittest.TestCase):
         
         # Expect a full packet to be written to the device
         expected_data = b'\x7E\x00\x04\x08AMY\x10'
-        self.assertEqual(serial_port.data, expected_data)
+        result_data   = serial_port.get_data_written()
+        self.assertEqual(result_data, expected_data)
         
         
     def test_send_at_command_with_param(self):
@@ -460,7 +461,7 @@ class TestWriteToDevice(unittest.TestCase):
         API AT command packet to the serial device.
         """
         
-        serial_port = FakeDevice()
+        serial_port = Serial()
         xbee = XBee(serial_port)
         
         # Send an AT command
@@ -472,8 +473,9 @@ class TestWriteToDevice(unittest.TestCase):
         )
         
         # Expect a full packet to be written to the device
+        result_data   = serial_port.get_data_written()
         expected_data = b'\x7E\x00\x06\x08AMY\x00\x00\x10'
-        self.assertEqual(serial_port.data, expected_data)
+        self.assertEqual(result_data, expected_data)
         
 class TestSendShorthand(unittest.TestCase):
     """
@@ -485,7 +487,7 @@ class TestSendShorthand(unittest.TestCase):
         """
         Prepare a fake device to read from
         """
-        self.ser = FakeDevice()
+        self.ser = Serial()
         self.xbee = XBee(self.ser)
     
     def test_send_at_command(self):
@@ -496,21 +498,23 @@ class TestSendShorthand(unittest.TestCase):
         self.xbee.at(frame_id=stringToBytes('A'), command=stringToBytes('MY'))
         
         # Expect a full packet to be written to the device
+        result_data = self.ser.get_data_written()
         expected_data = b'\x7E\x00\x04\x08AMY\x10'
-        self.assertEqual(self.ser.data, expected_data)
+        self.assertEqual(result_data, expected_data)
         
     def test_send_at_command_with_param(self):
         """
         calling send should write a full API frame containing the
         API AT command packet to the serial device.
         """
-        
+       
         # Send an AT command
         self.xbee.at(frame_id=stringToBytes('A'), command=stringToBytes('MY'), parameter=b'\x00\x00')
         
         # Expect a full packet to be written to the device
+        result_data = self.ser.get_data_written()
         expected_data = b'\x7E\x00\x06\x08AMY\x00\x00\x10'
-        self.assertEqual(self.ser.data, expected_data)
+        self.assertEqual(result_data, expected_data)
         
     def test_send_tx_with_close_brace(self):
         """
@@ -518,8 +522,9 @@ class TestSendShorthand(unittest.TestCase):
         must write correctly.
         """
         self.xbee.tx(dest_addr=b'\x01\x02',data=b'{test=1}')
+        result_data = self.ser.get_data_written()
         expected_data = b'\x7E\x00\x0D\x01\x00\x01\x02\x00{test=1}\xD5'
-        self.assertEqual(self.ser.data, expected_data)
+        self.assertEqual(result_data, expected_data)
         
     def test_shorthand_disabled(self):
         """
@@ -544,7 +549,8 @@ class TestReadFromDevice(unittest.TestCase):
         """
         read and parse a parameterless AT command
         """
-        device = FakeReadDevice(b'\x7E\x00\x05\x88DMY\x01\x8c')
+        device = Serial()
+        device.set_read_data(b'\x7E\x00\x05\x88DMY\x01\x8c')
         xbee = XBee(device)
         
         info = xbee.wait_read_frame()
@@ -558,9 +564,8 @@ class TestReadFromDevice(unittest.TestCase):
         """
         read and parse an AT command with a parameter
         """
-        device = FakeReadDevice(
-            b'\x7E\x00\x08\x88DMY\x01\x00\x00\x00\x8c'
-        )
+        device = Serial()
+        device.set_read_data(b'\x7E\x00\x08\x88DMY\x01\x00\x00\x00\x8c')
         xbee = XBee(device)
         
         info = xbee.wait_read_frame()
@@ -585,10 +590,8 @@ class TestReadFromDevice(unittest.TestCase):
         sample = b'\x00\xAA\x00\xFF'
         data = header + sample
         
-        device = FakeReadDevice(
-            APIFrame(data = b'\x88DIS\x00' + data).output()
-        )
-        
+        device = Serial()
+        device.set_read_data(APIFrame(data = b'\x88DIS\x00' + data).output());
         xbee = XBee(device)
         
         info = xbee.wait_read_frame()
@@ -616,10 +619,9 @@ class TestReadFromDevice(unittest.TestCase):
         # ADC0 value of 255
         sample = b'\x00\xAA\x00\xFF'
         data = header + sample
-        
-        device = FakeReadDevice(
-            APIFrame(data = b'\x97D\x00\x13\xa2\x00@oG\xe4v\x1aIS\x00' + data).output()
-        )
+       
+        device = Serial()
+        device.set_read_data(APIFrame(data = b'\x97D\x00\x13\xa2\x00@oG\xe4v\x1aIS\x00' + data).output())
         
         xbee = XBee(device)
         
@@ -655,9 +657,8 @@ class TestReadFromDevice(unittest.TestCase):
         # RX frame data
         rx_io_resp = b'\x83\x00\x01\x28\x00'
     
-        device = FakeReadDevice(
-            b'\x7E\x00\x0C'+ rx_io_resp + data + b'\xfd'
-        )
+        device = Serial()
+        device.set_read_data(b'\x7E\x00\x0C'+ rx_io_resp + data + b'\xfd')
         xbee = XBee(device)
         
         info = xbee.wait_read_frame()
@@ -681,16 +682,17 @@ class TestReadFromDevice(unittest.TestCase):
         an empty string. In this event, we must not crash.
         """
         
-        class BadReadDevice(FakeReadDevice):
+        class BadReadDevice(Serial):
             def __init__(self, bad_read_index, data):
                 self.read_id = 0
                 self.bad_read_index = bad_read_index
-                super(BadReadDevice, self).__init__(data)
+                super(BadReadDevice, self).__init__()
+                self.set_read_data(data)
             
-            def inWaiting(self):
+            def in_waiting(self):
                 return 1
                 
-            def read(self):
+            def read(self, length=1):
                 if self.read_id == self.bad_read_index:
                     self.read_id += 1
                     return ''
@@ -711,9 +713,8 @@ class TestReadFromDevice(unittest.TestCase):
         """
         read and parse an AT command with a parameter in escaped API mode
         """
-        device = FakeReadDevice(
-            b'~\x00\t\x88DMY\x01}^}]}1}3m'
-        )
+        device = Serial()
+        device.set_read_data(b'~\x00\t\x88DMY\x01}^}]}1}3m')
         xbee = XBee(device, escaped=True)
         
         info = xbee.wait_read_frame()
@@ -728,7 +729,8 @@ class TestReadFromDevice(unittest.TestCase):
         """
         If an empty frame is received from a device, it must be ignored.
         """
-        device = FakeReadDevice(b'\x7E\x00\x00\xFF\x7E\x00\x05\x88DMY\x01\x8c')
+        device = Serial()
+        device.set_read_data(b'\x7E\x00\x00\xFF\x7E\x00\x05\x88DMY\x01\x8c')
         xbee = XBee(device)
         
         #import pdb
@@ -744,7 +746,8 @@ class TestReadFromDevice(unittest.TestCase):
         """
         An rx data frame including a close brace must be read properly.
         """
-        device = FakeReadDevice(APIFrame(b'\x81\x01\x02\x55\x00{test=1}').output())
+        device = Serial()
+        device.set_read_data(APIFrame(b'\x81\x01\x02\x55\x00{test=1}').output())
         xbee = XBee(device)
         
         info = xbee.wait_read_frame()
@@ -759,9 +762,8 @@ class TestReadFromDevice(unittest.TestCase):
         """
         An escaped rx data frame including a close brace must be read properly.
         """
-        device = FakeReadDevice(
-            APIFrame(b'\x81\x01\x02\x55\x00{test=1}', escaped=True).output()
-        )
+        device = Serial()
+        device.set_read_data(APIFrame(b'\x81\x01\x02\x55\x00{test=1}', escaped=True).output())
         xbee = XBee(device, escaped=True)
         
         info = xbee.wait_read_frame()


### PR DESCRIPTION
This PR proposes a number of improvements to the Fake Serial device which is used by the python-xbee unit tests to simulate a serial device.
- Merged FakeDevice and FakeReadDevice into one.
- Added defaults for port, baudrate, timeout, xonxoff etc.
- Added readline() function.
- Added set_read_data() to set the data to be used by read() and readline().
- Added get_settings() Get a dictionary with port settings.
- Added get_data_written() returns data passed to write().
- Added further docstring comments.

The reason for these improvements are to support PR #27 which I am which adds support to base.py to attempt to recover from serial failure or unplug. In order for this to work I needed to embellish the Fake.py test device.
