### PR TITLE
Modernized setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,24 +1,23 @@
-from distutils.core import setup
-
-packages=[
-    'xbee',
-    'xbee.tests',
-    'xbee.helpers',
-    'xbee.helpers.dispatch',
-    'xbee.helpers.dispatch.tests',
-]
+from setuptools import setup, find_packages
 
 setup(
     name='XBee',
     version='2.2.3',
-    author='Paul Malmsten',
-    author_email='pmalmsten@gmail.com',
-    packages=packages,
-    scripts=[],
-    url='https://github.com/nioinnovation/python-xbee',
-    license='LICENSE.txt',
     description='Python tools for working with XBee radios',
     long_description=open('README.rst').read(),
-    requires=['serial'],
-    provides=packages,
+    url='https://github.com/nioinnovation/python-xbee',
+    author='Paul Malmsten',
+    author_email='pmalmsten@gmail.com',
+    license='MIT',
+    classifiers=[
+        'Development Status :: 5 - Production/Stable',
+        'Intended Audience :: Developers',
+        'License :: OSI Approved :: MIT License',
+        'Topic :: Terminals :: Serial',
+        'Programming Language :: Python',
+        'Programming Language :: Python :: 2'
+        'Programming Language :: Python :: 3'
+    ],
+    packages=find_packages(exclude=['tests', '*.tests']),
+    install_requires=['pyserial']
 )


### PR DESCRIPTION
Provided actually useful metadata and switched to setuptools (which is everywhere these days).

Installing xbee didn't pull pyserial with it because the setup.py metadata was wrong. This fixes it and corrects many other issues with it.