### PR TITLE
Make versioning work in __init__.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,13 +1,21 @@
+import re
 from setuptools import setup, find_packages
+
+# Auto detect the library version from the __init__.py file
+with open('xbee/__init__.py', 'r') as fd:
+    version = re.search(r'^__version__\s*=\s*[\'"]([^\'"]*)[\'"]',
+                        fd.read(), re.MULTILINE).group(1)
+if not version:
+    raise RuntimeError('Cannot find version information')
 
 setup(
     name='XBee',
-    version='2.2.4',
+    version=version,
     description='Python tools for working with XBee radios',
     long_description=open('README.rst').read(),
     url='https://github.com/nioinnovation/python-xbee',
-    author='Paul Malmsten',
-    author_email='pmalmsten@gmail.com',
+    author='n.io',
+    author_email='info@n.io',
     license='MIT',
     classifiers=[
         'Development Status :: 5 - Production/Stable',

--- a/setup.py
+++ b/setup.py
@@ -23,8 +23,8 @@ setup(
         'License :: OSI Approved :: MIT License',
         'Topic :: Terminals :: Serial',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2'
-        'Programming Language :: Python :: 3'
+        'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 3',
     ],
     packages=find_packages(exclude=['tests', '*.tests']),
     install_requires=['pyserial']

--- a/xbee/__init__.py
+++ b/xbee/__init__.py
@@ -1,9 +1,13 @@
 """
 XBee package initalization file
 
-By Paul Malmsten, 2010
-pmalmsten@gmail.com
+info@n.io
 """
+
+__title__ = 'xbee'
+__version__ = '2.2.4'
+__author__ = 'n.io'
+__license__ = 'MIT'
 
 from xbee.ieee import XBee
 from xbee.zigbee import ZigBee


### PR DESCRIPTION
This will let us keep the version information in the module's `__init__.py` file as the single source of truth. Doing this prevents version numbers from getting out of sync (i.e. `setup.py` updated but `__init__.py` not) and also lets the users of the module see the version number in a [standard Python fashion](https://www.python.org/dev/peps/pep-0008/#module-level-dunder-names).