### PR TITLE
Bump to version 2.2.5

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -38,7 +38,7 @@ v1.9.2 - 18 Aug 2010
 * Fixed bug where _write() call on a serial object should have been write().
 
 v2.0.0 - 29 Dec 2010
-* Added preiminary support for XBee ZB devices; thanks Greg and Brian!
+* Added preliminary support for XBee ZB devices; thanks Greg and Brian!
 * Improved & unified sample data header parsing code.
 * Improved documentation.
 
@@ -79,3 +79,10 @@ v2.2.4 - 17 Mar 2017
 * Do not break on error, rather log error.
 * Add Travis CI for unit tests.
 * Modernized setup.py.
+
+v2.2.5 - 25 Apr 2017
+* Formatting tidy in line with PEP8 recommendations.
+* Added 'create_source_route' and 'register_joining_device' Zigbee frame definitions.
+* Moved version information to __init__.py.
+* Fixed DigiMesh for Python 3.
+* Fixed DigiMesh 'tx' frame definition.

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,6 +1,6 @@
 The MIT License
 
-Copyright (c) 2010 Paul Malmsten, Greg Rapp, Brian, Amit Synderman, Marco Sangalli
+Copyright (c) 2017 Paul Malmsten, Greg Rapp, Brian, Amit Synderman, Marco Sangalli
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/xbee/__init__.py
+++ b/xbee/__init__.py
@@ -5,7 +5,7 @@ info@n.io
 """
 
 __title__ = 'xbee'
-__version__ = '2.2.4'
+__version__ = '2.2.5'
 __author__ = 'n.io'
 __license__ = 'MIT'
 

--- a/xbee/__init__.py
+++ b/xbee/__init__.py
@@ -5,7 +5,7 @@ info@n.io
 """
 
 __title__ = 'xbee'
-__version__ = '2.2.5'
+__version__ = '2.2.4'
 __author__ = 'n.io'
 __license__ = 'MIT'
 


### PR DESCRIPTION
Hi @hansmosh @mattdodge We have had a few nice additions recently, do you think it is appropriate to bump to 2.2.5 and publish on PyPi?
Summary of recent changes:
* Formatting tidy in line with PEP8 recommendations.
* Added 'create_source_route' and 'register_joining_device' Zigbee frame definitions.
* Moved version information to __init__.py.
* Fixed DigiMesh for Python 3.
* Fixed DigiMesh 'tx' frame definition.