### PR TITLE
Fix for Issue #50 Python3 Fix in _build_command()

### DIFF
--- a/xbee/base.py
+++ b/xbee/base.py
@@ -13,7 +13,7 @@ series-specific functionality.
 """
 import struct, threading, time
 from xbee.frame import APIFrame
-from xbee.python2to3 import byteToInt, intToByte
+from xbee.python2to3 import byteToInt, intToByte, stringToBytes
 
 class ThreadQuitException(Exception):
     pass
@@ -182,7 +182,7 @@ class XBeeBase(threading.Thread):
                 # Read this field's name from the function arguments dict
                 data = kwargs[field['name']]
                 if isinstance(data, str):
-                    data = str.encode(data)
+                    data = stringToBytes(data)
 
             except KeyError:
                 # Data wasn't given

--- a/xbee/base.py
+++ b/xbee/base.py
@@ -181,6 +181,9 @@ class XBeeBase(threading.Thread):
             try:
                 # Read this field's name from the function arguments dict
                 data = kwargs[field['name']]
+                if isinstance(data, str):
+                    data = str.encode(data)
+
             except KeyError:
                 # Data wasn't given
                 # Only a problem if the field has a specific length
@@ -205,9 +208,8 @@ class XBeeBase(threading.Thread):
                     "The data provided for '%s' was not %d bytes long"\
                     % (field['name'], field['len']))
 
-            # Add the data to the packet, if it has been specified
-            # Otherwise, the parameter was of variable length, and not
-            #  given
+            # Add the data to the packet, if it has been specified.
+            # Otherwise, the parameter was of variable length, and not given.
             if data:
                 packet += data
 
@@ -392,7 +394,6 @@ class XBeeBase(threading.Thread):
         """
         # Pass through the keyword arguments
         self._write(self._build_command(cmd, **kwargs))
-
 
     def wait_read_frame(self):
         """

--- a/xbee/python2to3.py
+++ b/xbee/python2to3.py
@@ -5,6 +5,7 @@ By Paul Malmsten, 2011
 
 Helper functions for handling Python 2 and Python 3 datatype shenanigans.
 """
+import sys
 
 def byteToInt(byte):
     """
@@ -31,4 +32,4 @@ def stringToBytes(s):
 
     Converts a string into an appropriate bytes object
     """
-    return s.encode('ascii')
+    return s.encode('ascii') if sys.version_info >= (3, 0) else s

--- a/xbee/tests/test_zigbee.py
+++ b/xbee/tests/test_zigbee.py
@@ -8,6 +8,7 @@ Tests the XBee ZB (ZigBee) implementation class for API compliance
 """
 import unittest
 from xbee.zigbee import ZigBee
+from xbee.tests.Fake import Serial
 
 class TestZigBee(unittest.TestCase):
     """
@@ -16,6 +17,17 @@ class TestZigBee(unittest.TestCase):
 
     def setUp(self):
         self.zigbee = ZigBee(None)
+
+    def test_send(self):
+        """
+        Test send() with AT command.
+        """
+        device = Serial()
+        xbee = ZigBee(device)
+        xbee.send('at', command='MY')
+        result = device.get_data_written()
+        expected = b'~\x00\x04\x08\x01MYP'
+        self.assertEqual(result, expected)
 
     def test_null_terminated_field(self):
         """


### PR DESCRIPTION
Running code:
```
zigbee = ZigBee(serial)
zigbee.send('at', command='MY')
```
Running on python3 causes error:
```
  File "../pyalertme/base.py", line 119, in read_addresses
    self._xbee.send('at', command='MY')
  File "/usr/local/lib/python3.5/site-packages/xbee/base.py", line 394, in send
    self._write(self._build_command(cmd, **kwargs))
  File "/usr/local/lib/python3.5/site-packages/xbee/base.py", line 212, in _build_command
    packet += data
TypeError: can't concat bytes to str
```

Caused because _build_command() tries to concat bytes with at command 'MY' of type string.
This solution proposes checking data type and converting to bytes.

Also written a small unit test to make sure now works. I am not totally sure if test_zigbee.py is the most appropriate place for it.

Fixes Issue #50 