### PR TITLE
Add Extended Modem Status frame type (0x98)

### DIFF
--- a/xbee/zigbee.py
+++ b/xbee/zigbee.py
@@ -162,6 +162,13 @@ class ZigBee(XBeeBase):
                 {'name':'status',             'len':1}
             ]
         },
+        b'\x98': {
+            'name': 'extended_status',
+            'structure': [
+                {'name': 'status',            'len': 1},
+                {'name': 'data',              'len': None}
+            ]
+        },
         b'\x8D': {
             'name': 'route_information',
             'structure': [


### PR DESCRIPTION
This commit adds support for the Extended Modem Status
frame type 0x98 as implemented in XBee S2C modules.
Reporting of Extended Modem Status is enabled with the
ATDC10 command.