### PR TITLE
Fix error Concat str + bytes

### DIFF
--- a/xbee/backend/base.py
+++ b/xbee/backend/base.py
@@ -115,9 +115,15 @@ class XBeeBase(object):
                 if field['len'] is not None:
                     # Was a default value specified?
                     default_value = field['default']
-                    
+
                     if isinstance(default_value, str):
-                        default_value = stringToBytes(default_value)
+                        try:
+                            default_value = stringToBytes(default_value)
+                        except Exception as e:
+                            default_aux = default_value
+                            default_value = b''
+                            for i in range(len(default_aux)):
+                                default_value = default_value+ b'\x00'
 
                     if default_value:
                         # If so, use it

--- a/xbee/backend/base.py
+++ b/xbee/backend/base.py
@@ -115,6 +115,10 @@ class XBeeBase(object):
                 if field['len'] is not None:
                     # Was a default value specified?
                     default_value = field['default']
+                    
+                    if isinstance(default_value, str):
+                        default_value = stringToBytes(default_value)
+
                     if default_value:
                         # If so, use it
                         data = default_value


### PR DESCRIPTION
This commit fix the error, when you do not insert all the arguments in the function and the default get error, because it is string and not byte. Used for the function bellow:

`self.send('at', frame_id='2', command='SH')
`

`default_value = field['default']`

